### PR TITLE
clarify packer version requirement in the readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,8 @@ We don't yet have the proper repository/tag information, so for now Packer leave
 - The easiest way is via `brew` with `brew install packer` (`brew info packer` first if you'd like).
 - If you'd prefer to avoid `brew` for some reason, [Download](https://www.packer.io/downloads/) from the web site and set up locally to execute.
 
+Note: Packer 1.5.6 or newer is required. You can check your installed version with `packer --version`. If necessary, run `brew upgrade packer` or download the latest version from Packer's website.
+
 ### Installing Docker
 
 - It looks like there's a core package, though `brew cask install docker` has worked fine to set up Docker Desktop for me on MacOS


### PR DESCRIPTION
`max_retries` is new in Packer 1.5.6. In typical Packer fashion, trying to build on an earlier version produces a sensical but verbose error,

```
➜ packer build demo.packer
docker: output will be in this color.

1 error occurred:
	* unknown configuration key: "max_retries"; raws is []interface {}{map[string]interface {}{"max_retries":3, "script":"scripts/getopticdemo.sh"}, map[string]interface {}{"packer_build_name":"docker", "packer_builder_type":"docker", "packer_debug":false, "packer_force":false, "packer_on_error":"", "packer_template_path":"/Users/nate/code/optic-demo/demo.packer", "packer_user_variables":map[interface {}]interface {}{}}}

 and ctx data is map[interface {}]interface {}{"ConnType":"Build_Type. To set this dynamically in the Packer template, you must use the `build` function", "Host":"Build_Host. To set this dynamically in the Packer template, you must use the `build` function", "ID":"Build_ID. To set this dynamically in the Packer template, you must use the `build` function", "PackerHTTPAddr":"Build_PackerHTTPAddr. To set this dynamically in the Packer template, you must use the `build` function", "PackerRunUUID":"Build_PackerRunUUID. To set this dynamically in the Packer template, you must use the `build` function", "Password":"Build_Password. To set this dynamically in the Packer template, you must use the `build` function", "Port":"Build_Port. To set this dynamically in the Packer template, you must use the `build` function", "SSHPrivateKey":"Build_SSHPrivateKey. To set this dynamically in the Packer template, you must use the `build` function", "SSHPublicKey":"Build_SSHPublicKey. To set this dynamically in the Packer template, you must use the `build` function", "User":"Build_User. To set this dynamically in the Packer template, you must use the `build` function", "WinRMPassword":"{{.WinRMPassword}}"}
```

I added a note about the minimum Packer version to the README.