### PR TITLE
tag the demo image

### DIFF
--- a/demo.packer
+++ b/demo.packer
@@ -46,5 +46,12 @@
       "type": "shell",
       "inline": "chmod 755 /root/change_posts.sh"
     }
+  ],
+  "post-processors": [
+    {
+      "type": "docker-tag",
+      "repository": "optic-demo",
+      "tag": "latest"
+    }
   ]
 }


### PR DESCRIPTION
the README calls out the docker image that Packer builds isn't tagged. if youre into it, this will tag the build as `optic-demo:latest` without trying to push it anywhere.